### PR TITLE
updated clamAV instructions for deployments and versioning. Removed t…

### DIFF
--- a/openshift/clamav/README.md
+++ b/openshift/clamav/README.md
@@ -53,9 +53,10 @@ oc -n <namespace> start-build bc/clamav-build
 ## Deployment
 
 Navigate to clamav-dc.yaml in your local machine and run the following command to deploy the pod to your namespace <<TAG>> is for the image ex. latest, 1.0.1
+<<namespace>> could be 75e61b-dev
 
 ```
-oc process -f clamav-dc.yaml -p TAG=<<TAG>> | oc apply -n 75e61b-dev -f -
+oc process -f clamav-dc.yaml -p TAG=<<TAG>> | oc apply -n <<namespace>> -f -
 ```
 
 ## Versioning Deployments
@@ -67,8 +68,8 @@ oc tag -n <<namespace>> clamav:latest clamav:<<TAG>>
 ```
 
 Method 1: apply a patch to the deployment config to point to the new image in DEV, TEST or PROD. Make sure to adjust the namespace appropriately. Ex.
-<<namespace>> would be 75e61b-dev,
-<<tools namespace>> would be 75e61b-tools.
+<<namespace>> could be 75e61b-dev,
+<<tools namespace>> could be 75e61b-tools.
 
 ```
 oc patch dc clamav -n <<namespace>> --type=json -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "image-registry.openshift-image-registry.svc:5000/<<tools namespace>>/clamav:<tag>" }]'

--- a/openshift/clamav/README.md
+++ b/openshift/clamav/README.md
@@ -19,7 +19,7 @@ Change to your build namespace (e.g. tools)
 ```
 oc project <namespace>
 ```
-  
+
 Import latest version
 
 ```
@@ -27,7 +27,9 @@ oc import-image ubi8/ubi:latest --from=registry.access.redhat.com/ubi8/ubi:lates
 ```
 
 ## Image pull setup
+
 Run the following command to allow your upper namespaces (DEV/TEST/PROD) to reach into tools to get the built ClamAV image:
+
 ```
 oc policy add-role-to-user system:image-puller system:serviceaccount:<namespace-prefix>-dev:default --namespace=<namespace-prefix>-tools
 oc policy add-role-to-user system:image-puller system:serviceaccount:<namespace-prefix>-test:default --namespace=<namespace-prefix>-tools
@@ -37,15 +39,45 @@ oc policy add-role-to-user system:image-puller system:serviceaccount:<namespace-
 ## Build
 
 Add the Build Configuration to the namespace
+
 ```
 oc -n <namspace> process -f "clamav-bc.yaml" | oc -n <namspace> create -f -
 ```
+
 Start the build
+
 ```
 oc -n <namespace> start-build bc/clamav-build
 ```
+
 ## Deployment
-Run the following command to deploy the pod to your namespace
+
+Navigate to clamav-dc.yaml in your local machine and run the following command to deploy the pod to your namespace <<TAG>> is for the image ex. latest, 1.0.1
+
 ```
-oc -n <namespace> process -f "clamav-dc.yaml" | oc -n <namespace> create -f -
+oc process -f clamav-dc.yaml -p TAG=<<TAG>> | oc apply -n 75e61b-dev -f -
+```
+
+## Versioning Deployments
+
+Tag the latest image in the tools environment
+
+```
+oc tag -n <<namespace>> clamav:latest clamav:<<TAG>>
+```
+
+Method 1: apply a patch to the deployment config to point to the new image in DEV, TEST or PROD. Make sure to adjust the namespace appropriately. Ex.
+<<namespace>> would be 75e61b-dev,
+<<tools namespace>> would be 75e61b-tools.
+
+```
+oc patch dc clamav -n <<namespace>> --type=json -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "image-registry.openshift-image-registry.svc:5000/<<tools namespace>>/clamav:<tag>" }]'
+```
+
+Method 2: process a new deployment config with the newest image tag <<TAG>> ex. 1.0.1 etc.
+<<namespace>> could be 75e61b-dev
+
+```
+oc process -f clamav-dc.yaml -p TAG=<<TAG>> | oc apply -n <<namespace>> -f -
+
 ```

--- a/openshift/clamav/openshift/templates/clamav-dc.yaml
+++ b/openshift/clamav/openshift/templates/clamav-dc.yaml
@@ -16,6 +16,12 @@ parameters:
     value: "2G"
   - name: REPLICAS
     value: "1"
+  - name: TAG
+    description: tag identifier for the image
+    required: true
+  - name: IMAGE_NAME
+    description: name for the clamav image
+    value: "clamav"
 objects:
   - kind: Service
     apiVersion: v1
@@ -49,15 +55,6 @@ objects:
         type: Rolling
         activeDeadlineSeconds: 21600
       triggers:
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - clamav
-            from:
-              kind: ImageStreamTag
-              namespace: "${NAME_SPACE}"
-              name: "clamav:latest"
         - type: ConfigChange
       replicas: ${{REPLICAS}}
       test: false
@@ -102,8 +99,10 @@ objects:
               ports:
                 - containerPort: 3310
                   protocol: TCP
-              imagePullPolicy: Always
               terminationMessagePolicy: File
+            - image: image-registry.openshift-image-registry.svc:5000/${NAME_SPACE}/${IMAGE_NAME}:${TAG}
+              name: clamav
+              imagePullPolicy: Always
           restartPolicy: Always
           terminationGracePeriodSeconds: 30
           dnsPolicy: ClusterFirst


### PR DESCRIPTION
…riggers for image changes in the DC since this was triggering deployments whenever we updated latest. Added instructions on how to version future deployts